### PR TITLE
_public_ VRF by default in BGP modules

### DIFF
--- a/library/ce_bgp.py
+++ b/library/ce_bgp.py
@@ -135,7 +135,7 @@ options:
         description:
             - Name of a BGP instance. The name is a case-sensitive string of characters.
         required: false
-        default: null
+        default: _public_
     vrf_rid_auto_sel:
         description:
             - If the value is true, VPN BGP instances are enabled to automatically select router IDs.
@@ -2050,7 +2050,7 @@ def main():
         hold_interval=dict(type='str'),
         clear_interval=dict(type='str'),
         confed_peer_as_num=dict(type='str'),
-        vrf_name=dict(type='str'),
+        vrf_name=dict(type='str', default='_public_'),
         vrf_rid_auto_sel=dict(type='str', default='no_use', choices=['no_use', 'true', 'false']),
         router_id=dict(type='str'),
         keepalive_time=dict(type='str'),

--- a/library/ce_bgp_af.py
+++ b/library/ce_bgp_af.py
@@ -41,7 +41,8 @@ options:
             - Name of a BGP instance. The name is a case-sensitive string of characters.
               The BGP instance can be used only after the corresponding VPN instance is created.
               The value is a string of 1 to 31 case-sensitive characters.
-        required: true
+        required: false
+        default: _public_
     af_type:
         description:
             - Address family type of a BGP instance.
@@ -3014,7 +3015,7 @@ def main():
 
     argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
-        vrf_name=dict(type='str', required=True),
+        vrf_name=dict(type='str', default='_public_'),
         af_type=dict(choices=['ipv4uni', 'ipv4multi', 'ipv4vpn',
                               'ipv6uni', 'ipv6vpn', 'evpn'], required=True),
         max_load_ibgp_num=dict(type='str'),

--- a/library/ce_bgp_neighbor.py
+++ b/library/ce_bgp_neighbor.py
@@ -40,7 +40,8 @@ options:
         description:
             - Name of a BGP instance. The name is a case-sensitive string of characters.
               The BGP instance can be used only after the corresponding VPN instance is created.
-        required: true
+        required: false
+        default: _public_
     peer_addr:
         description:
             - Connection address of a peer, which can be an IPv4 or IPv6 address.
@@ -1815,7 +1816,7 @@ def main():
 
     argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
-        vrf_name=dict(type='str', required=True),
+        vrf_name=dict(type='str', default='_public_'),
         peer_addr=dict(type='str', required=True),
         remote_as=dict(type='str', required=True),
         description=dict(type='str'),

--- a/library/ce_bgp_neighbor_af.py
+++ b/library/ce_bgp_neighbor_af.py
@@ -34,7 +34,8 @@ options:
         description:
             - Name of a BGP instance. The name is a case-sensitive string of characters.
               The BGP instance can be used only after the corresponding VPN instance is created.
-        required: true
+        required: false
+        default: _public_
     af_type:
         description:
             - Address family type of a BGP instance.
@@ -2367,7 +2368,7 @@ def main():
 
     argument_spec = dict(
         state=dict(choices=['present', 'absent'], default='present'),
-        vrf_name=dict(type='str', required=True),
+        vrf_name=dict(type='str', default='_public_'),
         af_type=dict(choices=['ipv4uni', 'ipv4multi', 'ipv4vpn',
                               'ipv6uni', 'ipv6vpn', 'evpn'], required=True),
         remote_address=dict(type='str', required=True),


### PR DESCRIPTION
Two commits:
- Modified BGP modules to use VRF _public_ by default
- Added support for IPv6 link-local addresses in ce_ip_interface