### PR TITLE
Mistake in the example in the file

### DIFF
--- a/library/ce_vlan.py
+++ b/library/ce_vlan.py
@@ -82,7 +82,7 @@ EXAMPLES = '''
     ce_vlan:
       vlan_id: 50
       name: WEB
-      state: absent
+      state: present
       provider: "{{ cli }}"
 
   - name: Ensure VLAN is NOT on the device


### PR DESCRIPTION
There is a mistake - absent instead of present keyword in the example.